### PR TITLE
Missing config_file argument

### DIFF
--- a/src/agrag/agrag.py
+++ b/src/agrag/agrag.py
@@ -122,11 +122,6 @@ class AutoGluonRAG:
         self.preset_quality = preset_quality
         self.model_ids = model_ids
 
-        if config_file:
-            self._load_config(config_file=config_file)
-        elif self.preset_quality:
-            self._load_preset()
-
         self.config = config_file or self._load_preset()
 
         self.args = Arguments(self.config)

--- a/src/agrag/agrag.py
+++ b/src/agrag/agrag.py
@@ -123,7 +123,7 @@ class AutoGluonRAG:
         self.model_ids = model_ids
 
         if config_file:
-            self._load_config()
+            self._load_config(config_file=config_file)
         elif self.preset_quality:
             self._load_preset()
 

--- a/src/agrag/args.py
+++ b/src/agrag/args.py
@@ -15,14 +15,8 @@ class Arguments:
 
     Attributes:
     ----------
-    args : argparse.Namespace
-        The parsed command-line arguments.
-    config : dict
-        The loaded configuration from the specified YAML file.
-    data_defaults : dict
-        The default values for the data processing module loaded from a YAML file.
-    embedding_defaults : dict
-        The default values for the embedding module loaded from a YAML file.
+    config_file : str
+        Path to configuration file
 
     Methods:
     -------


### PR DESCRIPTION
The config_file argument is missing when using config files as input.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
