### PR TITLE
Fix Argument Parsing for Command Line

### DIFF
--- a/docs/tutorials/usage.md
+++ b/docs/tutorials/usage.md
@@ -20,13 +20,25 @@ You can now use the package in two ways.
 AutoGluon-RAG
 
 
-usage: agrag [-h] --config_file
+usage: agrag [-h] [--config_file] [--preset_quality] [--web_urls [...]]
+             [--base_urls [...]] [--parse_urls_recursive] [--data_dir]
 
 AutoGluon-RAG - Retrieval-Augmented Generation Pipeline
 
 options:
-  -h, --help        show this help message and exit
-  --config_file        Path to the configuration file 
+  -h, --help            show this help message and exit
+  --config_file         Path to the configuration file
+  --preset_quality      Preset quality settings for the RAG pipeline
+                        (default: medium_quality)
+  --web_urls [ ...]     List of URLs to use for RAG
+  --base_urls [ ...]    List of base URLs to restrict web URL parsing.
+                        Only URLs stemming from a base URL will be
+                        processed.
+  --parse_urls_recursive
+                        Enable recursive parsing of all URLs from the
+                        provided web URL list
+  --data_dir            Directory containing files to use for RAG.
+                        Supports local or S3 paths.
 ```
 
 ## Use AutoGluon-RAG through code:
@@ -37,12 +49,10 @@ from agrag.agrag import AutoGluonRAG
 def ag_rag():
     agrag = AutoGluonRAG(
         preset_quality="medium_quality", # or path to config file
-        web_urls=["https://auto.gluon.ai/stable/index.html"], # List of URLs to use for RAG
-        base_urls=["https://auto.gluon.ai/stable/"], # List of base URLs to use when processing web     
-                                                     # URLs. Only Web URLs that stem from a base URL 
-                                                     # will be processed.
-        parse_urls_recursive=True, # Whether to recursively parse all URLs from the provided web url list
-        data_dir="s3://autogluon-rag-github-dev/autogluon_docs/" # Directory containing files to use for RAG
+        web_urls=["https://auto.gluon.ai/stable/index.html"],
+        base_urls=["https://auto.gluon.ai/stable/"],
+        parse_urls_recursive=True,
+        data_dir="s3://autogluon-rag-github-dev/autogluon_docs/"
     )
     agrag.initialize_rag_pipeline() # Initializes all modules in the RAG pipeline
     agrag.generate_response("What is AutoGluon?") # Generator

--- a/docs/tutorials/usage.md
+++ b/docs/tutorials/usage.md
@@ -5,7 +5,7 @@ To use this framework, you must first install AutoGluon RAG:
 git clone https://github.com/autogluon/autogluon-rag
 cd autogluon-rag
 
-# Create a Virtual Environment (using Python, or conda if you prefer)
+# Create a virtual environment (using Python, or conda if you prefer)
 python3 -m virtualenv venv
 source venv/bin/activate
 

--- a/src/agrag/agrag.py
+++ b/src/agrag/agrag.py
@@ -126,7 +126,7 @@ class AutoGluonRAG:
         self.model_ids = model_ids
 
         self.config = config_file or self._load_preset()
-        self.args = Arguments(config_file and self.config)
+        self.args = Arguments(self.config) if not self.args else self.args
 
         # will short-circuit to provided data_dir if config value also provided
         self.data_dir = data_dir or self.args.data_dir

--- a/src/agrag/agrag.py
+++ b/src/agrag/agrag.py
@@ -120,12 +120,13 @@ class AutoGluonRAG:
         """
         logger.info("\n\nAutoGluon-RAG\n\n")
 
+        self.args = Arguments(config_file)
+
         self.preset_quality = preset_quality
         self.model_ids = model_ids
 
         self.config = config_file or self._load_preset()
-
-        self.args = Arguments(self.config)
+        self.args = Arguments(config_file and self.config)
 
         # will short-circuit to provided data_dir if config value also provided
         self.data_dir = data_dir or self.args.data_dir

--- a/src/agrag/args.py
+++ b/src/agrag/args.py
@@ -47,9 +47,37 @@ class Arguments:
 
     def _parse_args(self) -> argparse.Namespace:
         parser = argparse.ArgumentParser(description="AutoGluon-RAG - Retrieval-Augmented Generation Pipeline")
+
+        parser.add_argument("--config_file", type=str, help="Path to the configuration file", metavar="")
+
         parser.add_argument(
-            "--config_file", type=str, help="Path to the configuration file", metavar="", required=True
+            "--preset_quality",
+            type=str,
+            choices=["low_quality", "medium_quality", "high_quality"],
+            default="medium_quality",
+            help="Preset quality settings for the RAG pipeline (default: medium_quality)",
+            metavar="",
         )
+        parser.add_argument("--web_urls", type=str, nargs="*", help="List of URLs to use for RAG", metavar="")
+        parser.add_argument(
+            "--base_urls",
+            type=str,
+            nargs="*",
+            help="List of base URLs to restrict web URL parsing. Only URLs stemming from a base URL will be processed.",
+            metavar="",
+        )
+        parser.add_argument(
+            "--parse_urls_recursive",
+            action="store_true",
+            help="Enable recursive parsing of all URLs from the provided web URL list",
+        )
+        parser.add_argument(
+            "--data_dir",
+            type=str,
+            help="Directory containing files to use for RAG. Supports local or S3 paths.",
+            metavar="",
+        )
+
         return parser.parse_args()
 
     def _load_config(self, config_file: str) -> dict:

--- a/src/agrag/main.py
+++ b/src/agrag/main.py
@@ -3,11 +3,13 @@ from agrag.agrag import AutoGluonRAG
 
 def ag_rag():
     agrag = AutoGluonRAG(
-        preset_quality="medium_quality",
-        web_urls=["https://auto.gluon.ai/stable/index.html"],
-        base_urls=["https://auto.gluon.ai/stable/"],
-        parse_urls_recursive=True,
-        data_dir="s3://autogluon-rag-github-dev/autogluon_docs/",
+        preset_quality="medium_quality",  # or path to config file
+        web_urls=["https://auto.gluon.ai/stable/index.html"],  # List of URLs to use for RAG
+        base_urls=["https://auto.gluon.ai/stable/"],  # List of base URLs to use when processing web
+        # URLs. Only Web URLs that stem from a base URL
+        # will be processed.
+        parse_urls_recursive=True,  # Whether to recursively parse all URLs from the provided web url list
+        data_dir="s3://autogluon-rag-github-dev/autogluon_docs/",  # Directory containing files to use for RAG
     )
 
     agrag.initialize_rag_pipeline()


### PR DESCRIPTION
## Description
Fixed argument parsing when command line is used for AutoGluon-RAG. 
Now, `agrag -h` works
Updated documentation as well

```
AutoGluon-RAG


Loading Preset 'medium_quality' configuration
usage: agrag [-h] [--config_file] [--preset_quality] [--web_urls [...]]
             [--base_urls [...]] [--parse_urls_recursive] [--data_dir]

AutoGluon-RAG - Retrieval-Augmented Generation Pipeline

options:
  -h, --help            show this help message and exit
  --config_file         Path to the configuration file
  --preset_quality      Preset quality settings for the RAG pipeline
                        (default: medium_quality)
  --web_urls [ ...]     List of URLs to use for RAG
  --base_urls [ ...]    List of base URLs to restrict web URL parsing.
                        Only URLs stemming from a base URL will be
                        processed.
  --parse_urls_recursive
                        Enable recursive parsing of all URLs from the
                        provided web URL list
  --data_dir            Directory containing files to use for RAG.
                        Supports local or S3 paths.
```

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify)

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] My code follows the project's coding style
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have updated the documentation accordingly
- [X] I have added appropriate comments to my code, particularly in hard-to-understand areas

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.